### PR TITLE
Show less log output during build and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN cp -r /build/packages/rating-tracker-frontend/dist /build/packages/rating-tr
 
 # Delete frontend code, caches only used by frontend, and unused TypeScript output
 RUN rm -r /build/packages/rating-tracker-frontend
-RUN echo yarn: $(yarn | grep "appears to be unused - removing" | wc -l) packages appear to be unused - removing
+RUN echo -e '\033[0;34m➤\033[0m YN0019: \033[0;35m'$(yarn | grep "appears to be unused - removing" | wc -l)' packages\033[0m appear to be unused - removing'
 RUN find /build/packages -type f '(' -name "*.d.ts*" -o -name "*.tsbuildinfo" ')' -delete
 
 # Create directories for run container and copy only necessary files

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN cp -r /build/packages/rating-tracker-frontend/dist /build/packages/rating-tr
 
 # Delete frontend code, caches only used by frontend, and unused TypeScript output
 RUN rm -r /build/packages/rating-tracker-frontend
-RUN echo -e '\033[0;34m➤\033[0m YN0019: \033[0;35m'$(yarn | grep "appears to be unused - removing" | wc -l)' packages\033[0m appear to be unused - removing'
+RUN echo -e "\033[0;34m➤\033[0m YN0019: \033[0;35m$(yarn | grep -c 'appears to be unused - removing') packages\033[0m appear to be unused - removing"
 RUN find /build/packages -type f '(' -name "*.d.ts*" -o -name "*.tsbuildinfo" ')' -delete
 
 # Create directories for run container and copy only necessary files

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,13 @@ RUN echo -e "\033[0;34m➤\033[0m YN0019: \033[0;35m$(yarn | grep -c 'appears to
 RUN find /build/packages -type f '(' -name "*.d.ts*" -o -name "*.tsbuildinfo" ')' -delete
 
 # Create directories for run container and copy only necessary files
-RUN mkdir -p /build/app/packages/rating-tracker-backend /build/app/packages/rating-tracker-commons /build/app/.yarn
-RUN cp -r /build/.pnp.* /build/package.json /build/yarn.lock /build/app
-RUN cp -r /build/.yarn/cache /build/.yarn/releases /build/.yarn/unplugged /build/app/.yarn
-RUN cp -r /build/packages/rating-tracker-backend/dist /build/packages/rating-tracker-backend/public /build/packages/rating-tracker-backend/package.json /build/app/packages/rating-tracker-backend
-RUN cp -r /build/packages/rating-tracker-commons/dist /build/packages/rating-tracker-commons/package.json /build/app/packages/rating-tracker-commons
-
-# should contain the yarnPath
-RUN tail -1 .yarnrc.yml > /build/app/.yarnrc.yml
+RUN mkdir -p /build/app/packages/rating-tracker-backend /build/app/packages/rating-tracker-commons /build/app/.yarn && \
+  cp -r /build/.pnp.* /build/package.json /build/yarn.lock /build/app && \
+  cp -r /build/.yarn/cache /build/.yarn/releases /build/.yarn/unplugged /build/app/.yarn && \
+  cp -r /build/packages/rating-tracker-backend/dist /build/packages/rating-tracker-backend/public /build/packages/rating-tracker-backend/package.json /build/app/packages/rating-tracker-backend && \
+  cp -r /build/packages/rating-tracker-commons/dist /build/packages/rating-tracker-commons/package.json /build/app/packages/rating-tracker-commons && \
+  # should contain the yarnPath
+  tail -1 .yarnrc.yml > /build/app/.yarnrc.yml
 
 FROM node:19.1.0-alpine3.16 as run
 RUN apk add --no-cache dumb-init

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN cp -r /build/packages/rating-tracker-frontend/dist /build/packages/rating-tr
 
 # Delete frontend code, caches only used by frontend, and unused TypeScript output
 RUN rm -r /build/packages/rating-tracker-frontend
-RUN yarn
+RUN echo yarn: $(yarn | grep "appears to be unused - removing" | wc -l) packages appear to be unused - removing
 RUN find /build/packages -type f '(' -name "*.d.ts*" -o -name "*.tsbuildinfo" ')' -delete
 
 # Create directories for run container and copy only necessary files

--- a/packages/rating-tracker-backend/package.json
+++ b/packages/rating-tracker-backend/package.json
@@ -15,10 +15,10 @@
     "dev:ssh": "ssh -N rating-tracker-port-forwarding",
     "dev:tsc": "tsc --watch",
     "dev:node": "node --watch dist/src/server.js",
-    "test:watch": "yarn node --experimental-vm-modules $(yarn bin jest) --watch --runInBand",
+    "test:watch": "yarn node --experimental-vm-modules $(yarn bin jest) --watch --runInBand --silent",
     "start": "node dist/src/server.js",
     "build": "tsc --project tsconfig.build.json",
-    "test": "yarn node --experimental-vm-modules $(yarn bin jest) --runInBand --coverage",
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest) --runInBand --coverage --silent",
     "lint": "eslint --ext .jsx,.js,.tsx,.ts src/",
     "lint:fix": "eslint --ext .jsx,.js,.tsx,.ts src/ --fix"
   },


### PR DESCRIPTION
- Run jest with `--silent`
- Hide list of packages removed during build using pretty and `yarn`-like message
- Summarize cp commands