### PR TITLE
Reduce Signal messages for errors during fetching

### DIFF
--- a/packages/rating-tracker-backend/src/redis/repositories/stock/stockRepository.ts
+++ b/packages/rating-tracker-backend/src/redis/repositories/stock/stockRepository.ts
@@ -10,7 +10,7 @@ import {
   Size,
   Style,
 } from "rating-tracker-commons";
-import { sendMessage } from "../../../signal/signal.js";
+import * as signal from "../../../signal/signal.js";
 import logger from "../../../lib/logger.js";
 
 export const indexStockRepository = () => {
@@ -156,7 +156,7 @@ export const updateStockWithoutReindexing = async (
     if (isNewData) {
       await save(stockEntity);
       if (signalMessage.includes("\n")) {
-        sendMessage(signalMessage);
+        signal.sendMessage(signalMessage);
       }
     } else {
       logger.info(chalk.grey(`No updates for stock ${ticker}.`));

--- a/packages/rating-tracker-backend/src/redis/repositories/user/userRepository.ts
+++ b/packages/rating-tracker-backend/src/redis/repositories/user/userRepository.ts
@@ -2,7 +2,7 @@ import APIError from "../../../lib/apiError.js";
 import { User, UserEntity, userSchema } from "../../../models/user.js";
 import { fetch, save } from "./userRepositoryBase.js";
 import chalk from "chalk";
-import { sendMessage } from "../../../signal/signal.js";
+import * as signal from "../../../signal/signal.js";
 import logger from "../../../lib/logger.js";
 
 /* istanbul ignore next */
@@ -24,7 +24,9 @@ export const createUser = async (user: User): Promise<boolean> => {
       `Created user “${user.name}” with entity ID ${await save(userEntity)}.`
     )
   );
-  sendMessage(`New user “${user.name}” (email ${user.email}) registered.`);
+  signal.sendMessage(
+    `New user “${user.name}” (email ${user.email}) registered.`
+  );
   return true;
 };
 

--- a/packages/rating-tracker-frontend/src/content/modules/stocklist/AddStock.tsx
+++ b/packages/rating-tracker-frontend/src/content/modules/stocklist/AddStock.tsx
@@ -372,6 +372,9 @@ const AddStock = (props: AddStockProps) => {
               </LoadingButton>
             </Grid>
           </Grid>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            You can always add more data providers later.
+          </Typography>
         </>
       ),
       noStepBack: true,
@@ -397,6 +400,7 @@ const AddStock = (props: AddStockProps) => {
           <Typography variant="h4" sx={{ mb: 2 }}>
             Here’s your new stock:
           </Typography>
+          {/* TODO: Check extracted data */}
           <TableContainer>
             <Table size="small">
               <TableBody>
@@ -405,6 +409,11 @@ const AddStock = (props: AddStockProps) => {
               </TableBody>
             </Table>
           </TableContainer>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            Please check whether all expected fields are filled. If a field is
+            not filled, an alert will not be raised when the information cannot
+            be extracted at a later time.
+          </Typography>
         </>
       ),
       buttonColor: "success",


### PR DESCRIPTION
* Collect error messages per stock
* Only send message when error is unexpected (i.e. extraction worked before)
* Only send MSCI message when three previous extractions failed
* Cleanup code (signal module import, XPath strings)
* Add explanatory texts to Add Stock dialog