### PR TITLE
Improve searching by ticker

### DIFF
--- a/packages/rating-tracker-backend/src/controllers/StockController.ts
+++ b/packages/rating-tracker-backend/src/controllers/StockController.ts
@@ -55,7 +55,7 @@ export class StockController {
         OR: [
           {
             ticker: {
-              contains: (req.query.name as string).trim(),
+              startsWith: (req.query.name as string).trim(),
               mode: "insensitive",
             },
           },
@@ -466,6 +466,7 @@ export class StockController {
     if (sortBy && typeof sortBy === "string" && isSortableAttribute(sortBy)) {
       const sort = String(req.query.sortDesc).toLowerCase() === "true" ? "desc" : "asc";
       switch (sortBy) {
+        case "ticker":
         case "name":
         case "size":
         case "style":

--- a/packages/rating-tracker-commons/src/lib/SortableAttribute.ts
+++ b/packages/rating-tracker-commons/src/lib/SortableAttribute.ts
@@ -4,6 +4,7 @@
 export const sortableAttributeArray =
   // : Partial<(keyof Stock)[]>
   [
+    "ticker",
     "name",
     "size",
     "style",

--- a/packages/rating-tracker-frontend/src/layouts/SidebarLayout/Header/Buttons/Search/index.tsx
+++ b/packages/rating-tracker-frontend/src/layouts/SidebarLayout/Header/Buttons/Search/index.tsx
@@ -198,7 +198,7 @@ const HeaderSearch = (): JSX.Element => {
       .get(baseUrl + stockListEndpointPath, {
         params: {
           name: currentSearchValue,
-          sortBy: "name",
+          sortBy: "ticker",
           count: 10, // Only request the first 10 results
         },
       })

--- a/packages/rating-tracker-frontend/src/layouts/SidebarLayout/Header/Buttons/Search/index.tsx
+++ b/packages/rating-tracker-frontend/src/layouts/SidebarLayout/Header/Buttons/Search/index.tsx
@@ -199,11 +199,20 @@ const HeaderSearch = (): JSX.Element => {
         params: {
           name: currentSearchValue,
           sortBy: "ticker",
-          count: 10, // Only request the first 10 results
         },
       })
       .then((res) => {
-        setStocks(res.data.stocks);
+        const upperCaseSearchValue = currentSearchValue.toLocaleUpperCase();
+        setStocks(
+          res.data.stocks
+            .sort(
+              // Sort stocks to the top if their ticker starts with the search value (case-insensitive)
+              (a: Stock, b: Stock) =>
+                +b.ticker.toLocaleUpperCase().startsWith(upperCaseSearchValue) -
+                +a.ticker.toLocaleUpperCase().startsWith(upperCaseSearchValue)
+            )
+            .slice(0, 10) // Only use the first 10 results
+        );
         setCount(res.data.count);
       })
       .catch((e) => {


### PR DESCRIPTION
* Change ticker filter key to `startsWith`
* Add `ticker` to sortable attributes
* Let the search bar request all matching stocks sorted by tickers
* Sort stocks to the top if their ticker starts with the search value
* Slice the result array to show the first 10 results
