### PR TITLE
Allow clearing information from one data provider before fetching

### DIFF
--- a/packages/rating-tracker-backend/src/controllers/FetchController.ts
+++ b/packages/rating-tracker-backend/src/controllers/FetchController.ts
@@ -209,19 +209,19 @@ export class FetchController {
         );
         continue;
       }
-      let industry: Industry;
-      let size: Size;
-      let style: Style;
-      let starRating: number;
-      let dividendYieldPercent: number;
-      let priceEarningRatio: number;
-      let currency: Currency;
-      let lastClose: number;
-      let morningstarFairValue: number;
-      let marketCap: number;
-      let low52w: number;
-      let high52w: number;
-      let description: string;
+      let industry: Industry = req.query.clear ? null : undefined;
+      let size: Size = req.query.clear ? null : undefined;
+      let style: Style = req.query.clear ? null : undefined;
+      let starRating: number = req.query.clear ? null : undefined;
+      let dividendYieldPercent: number = req.query.clear ? null : undefined;
+      let priceEarningRatio: number = req.query.clear ? null : undefined;
+      let currency: Currency = req.query.clear ? null : undefined;
+      let lastClose: number = req.query.clear ? null : undefined;
+      let morningstarFairValue: number = req.query.clear ? null : undefined;
+      let marketCap: number = req.query.clear ? null : undefined;
+      let low52w: number = req.query.clear ? null : undefined;
+      let high52w: number = req.query.clear ? null : undefined;
+      let description: string = req.query.clear ? null : undefined;
 
       try {
         await driver.get(
@@ -481,7 +481,7 @@ export class FetchController {
               marketCap = +marketCapText;
             }
             if (!marketCapText.match(/\d+/) || Number.isNaN(marketCap)) {
-              marketCap = undefined;
+              marketCap = req.query.clear ? null : undefined;
               throw new TypeError(`Extracted market capitalization is no valid number.`);
             }
           }
@@ -615,8 +615,8 @@ export class FetchController {
         );
         await new Promise((resolve) => setTimeout(resolve, 3000)); // Cool down for 3 seconds.
       }
-      if (consecutiveErrorCount >= 5) {
-        // If we have 5 consecutive errors, we stop fetching data, since something is probably wrong.
+      if (consecutiveErrorCount >= 10) {
+        // If we have 10 consecutive errors, we stop fetching data, since something is probably wrong.
         logger.error(
           PREFIX_SELENIUM +
             chalk.redBright(
@@ -713,9 +713,9 @@ export class FetchController {
         );
         continue;
       }
-      let analystConsensus: number;
-      let analystCount: number;
-      let analystTargetPrice: number;
+      let analystConsensus: number = req.query.clear ? null : undefined;
+      let analystCount: number = req.query.clear ? null : undefined;
+      let analystTargetPrice: number = req.query.clear ? null : undefined;
 
       try {
         await driver.get(`https://www.marketscreener.com/quote/stock/${stock.marketScreenerID}/`);
@@ -993,8 +993,8 @@ export class FetchController {
         );
         break;
       }
-      let msciESGRating: MSCIESGRating;
-      let msciTemperature: number;
+      let msciESGRating: MSCIESGRating = req.query.clear ? null : undefined;
+      let msciTemperature: number = req.query.clear ? null : undefined;
 
       try {
         await driver.manage().deleteAllCookies(); // Delete all cookies since MSCI allows only 4 requests per session.
@@ -1215,8 +1215,8 @@ export class FetchController {
         );
         continue;
       }
-      let refinitivESGScore: number;
-      let refinitivEmissions: number;
+      let refinitivESGScore: number = req.query.clear ? null : undefined;
+      let refinitivEmissions: number = req.query.clear ? null : undefined;
 
       try {
         // Delete all cookies since Refinitiv allows only 100 requests per session.
@@ -1439,7 +1439,7 @@ export class FetchController {
         );
         continue;
       }
-      let spESGScore: number;
+      let spESGScore: number = req.query.clear ? null : undefined;
 
       try {
         await driver.get(`https://www.spglobal.com/esg/scores/results?cid=${stock.spID}`);
@@ -1632,7 +1632,7 @@ export class FetchController {
     const sustainalyticsXMLLines = sustainalyticsXMLResource.content.split("\n");
 
     for await (const stock of stocks) {
-      let sustainalyticsESGRisk: number;
+      let sustainalyticsESGRisk: number = req.query.clear ? null : undefined;
 
       try {
         // Look for the Sustainalytics ID in the XML lines.

--- a/packages/rating-tracker-backend/src/controllers/StockController.live.test.ts
+++ b/packages/rating-tracker-backend/src/controllers/StockController.live.test.ts
@@ -16,6 +16,7 @@ import {
   expectStockListLengthToBe,
   supertest,
 } from "../../test/liveTestHelpers";
+import { sentMessages } from "../signal/__mocks__/signalBase";
 import client from "../db/client";
 
 export const suiteName = "Stock API";
@@ -391,13 +392,13 @@ tests.push({
   testName: "supports pagination",
   testFunction: async () => {
     const resAllStocks = await supertest
-      .get(`/api${stockListEndpointPath}`)
+      .get(`/api${stockListEndpointPath}?sortBy=name`)
       .set("Cookie", ["authToken=exampleSessionID"]);
     expect(resAllStocks.status).toBe(200);
     expect(resAllStocks.body.count).toBe(11);
     expect(resAllStocks.body.stocks).toHaveLength(11);
     const resPagination = await supertest
-      .get(`/api${stockListEndpointPath}?offset=5&count=5`)
+      .get(`/api${stockListEndpointPath}?sortBy=name&offset=5&count=5`)
       .set("Cookie", ["authToken=exampleSessionID"]);
     expect(resPagination.body.stocks[0].name).toBe(resAllStocks.body.stocks[5].name);
     expect(resPagination.body.stocks[4].name).toBe(resAllStocks.body.stocks[9].name);
@@ -538,6 +539,17 @@ tests.push({
     expect((res.body as Stock).name).toEqual("Apple Inc");
     expect((res.body as Stock).morningstarID).toBeNull();
     expect((res.body as Stock).spID).toBeNull();
+    // Removing a data provider’s ID removes attribute values related to it as well
+    expect((res.body as Stock).industry).toBeNull();
+    expect((res.body as Stock).size).toBeNull();
+    expect((res.body as Stock).style).toBeNull();
+    expect((res.body as Stock).starRating).toBeNull();
+    expect((res.body as Stock).morningstarFairValue).toBeNull();
+    expect((res.body as Stock).morningstarFairValuePercentageToLastClose).toBeNull();
+    expect((res.body as Stock).marketCap).toBeNull();
+    expect((res.body as Stock).spESGScore).toBeNull();
+    expect(sentMessages[0].message).toMatch("🔴");
+    expect(sentMessages[0].message).not.toMatch("🟢");
   },
 });
 

--- a/packages/rating-tracker-backend/src/controllers/StockController.ts
+++ b/packages/rating-tracker-backend/src/controllers/StockController.ts
@@ -655,7 +655,7 @@ export class StockController {
   async patch(req: Request, res: Response) {
     const ticker = req.params[0];
     const { name, isin, country, morningstarID, marketScreenerID, msciID, ric, sustainalyticsID } = req.query;
-    const spID = req.query.spID === null ? "" : req.query.spID;
+    const spID = req.query.spID === null ? "" : req.query.spID ? +req.query.spID : undefined;
     if (
       typeof ticker === "string" &&
       (typeof name === "string" || typeof name === "undefined") &&
@@ -668,16 +668,40 @@ export class StockController {
       ((typeof spID === "string" && spID === "") || typeof spID === "number" || typeof spID === "undefined") &&
       (typeof sustainalyticsID === "string" || typeof sustainalyticsID === "undefined")
     ) {
+      // If a data provider ID is removed (i.e., set to an empty string), we remove all information available from that
+      // data provider as well.
       await updateStock(ticker, {
         name,
         isin,
         country,
         morningstarID: morningstarID === "" ? null : morningstarID,
+        industry: morningstarID === "" ? null : undefined,
+        size: morningstarID === "" ? null : undefined,
+        style: morningstarID === "" ? null : undefined,
+        starRating: morningstarID === "" ? null : undefined,
+        dividendYieldPercent: morningstarID === "" ? null : undefined,
+        priceEarningRatio: morningstarID === "" ? null : undefined,
+        currency: morningstarID === "" ? null : undefined,
+        lastClose: morningstarID === "" ? null : undefined,
+        morningstarFairValue: morningstarID === "" ? null : undefined,
+        marketCap: morningstarID === "" ? null : undefined,
+        low52w: morningstarID === "" ? null : undefined,
+        high52w: morningstarID === "" ? null : undefined,
+        description: morningstarID === "" ? null : undefined,
         marketScreenerID: marketScreenerID === "" ? null : marketScreenerID,
+        analystConsensus: marketScreenerID === "" ? null : undefined,
+        analystCount: marketScreenerID === "" ? null : undefined,
+        analystTargetPrice: marketScreenerID === "" ? null : undefined,
         msciID: msciID === "" ? null : msciID,
+        msciESGRating: msciID === "" ? null : undefined,
+        msciTemperature: msciID === "" ? null : undefined,
         ric: ric === "" ? null : ric,
-        spID: spID === "" ? null : (spID as unknown as number | null | undefined),
+        refinitivESGScore: ric === "" ? null : undefined,
+        refinitivEmissions: ric === "" ? null : undefined,
+        spID: spID === "" ? null : spID,
+        spESGScore: spID === "" ? null : undefined,
         sustainalyticsID: sustainalyticsID === "" ? null : sustainalyticsID,
+        sustainalyticsESGRisk: sustainalyticsID === "" ? null : undefined,
       });
       res.status(204).end();
     }

--- a/packages/rating-tracker-backend/src/openapi/parameters/fetch.ts
+++ b/packages/rating-tracker-backend/src/openapi/parameters/fetch.ts
@@ -26,4 +26,17 @@ const noSkip: OpenAPIV3.ParameterObject = {
   },
 };
 
-export { detach, noSkip };
+/**
+ * Whether to clear information related to the data provider before fetching
+ */
+const clear: OpenAPIV3.ParameterObject = {
+  in: "query",
+  name: "clear",
+  description: "Whether to clear information related to the data provider before fetching",
+  schema: {
+    type: "boolean",
+    example: "false",
+  },
+};
+
+export { detach, noSkip, clear };

--- a/packages/rating-tracker-backend/src/openapi/paths/fetch/marketScreenerEndpoint.ts
+++ b/packages/rating-tracker-backend/src/openapi/paths/fetch/marketScreenerEndpoint.ts
@@ -22,6 +22,7 @@ const post: OpenAPIV3.OperationObject = {
     },
     fetch.detach,
     fetch.noSkip,
+    fetch.clear,
   ],
   responses: {
     "200": okStockList,

--- a/packages/rating-tracker-backend/src/openapi/paths/fetch/morningstarEndpoint.ts
+++ b/packages/rating-tracker-backend/src/openapi/paths/fetch/morningstarEndpoint.ts
@@ -22,6 +22,7 @@ const post: OpenAPIV3.OperationObject = {
     },
     fetch.detach,
     fetch.noSkip,
+    fetch.clear,
   ],
   responses: {
     "200": okStockList,

--- a/packages/rating-tracker-backend/src/openapi/paths/fetch/msciEndpoint.ts
+++ b/packages/rating-tracker-backend/src/openapi/paths/fetch/msciEndpoint.ts
@@ -22,6 +22,7 @@ const post: OpenAPIV3.OperationObject = {
     },
     fetch.detach,
     fetch.noSkip,
+    fetch.clear,
   ],
   responses: {
     "200": okStockList,

--- a/packages/rating-tracker-backend/src/openapi/paths/fetch/refinitivEndpoint.ts
+++ b/packages/rating-tracker-backend/src/openapi/paths/fetch/refinitivEndpoint.ts
@@ -22,6 +22,7 @@ const post: OpenAPIV3.OperationObject = {
     },
     fetch.detach,
     fetch.noSkip,
+    fetch.clear,
   ],
   responses: {
     "200": okStockList,

--- a/packages/rating-tracker-backend/src/openapi/paths/fetch/spEndpoint.ts
+++ b/packages/rating-tracker-backend/src/openapi/paths/fetch/spEndpoint.ts
@@ -22,6 +22,7 @@ const post: OpenAPIV3.OperationObject = {
     },
     fetch.detach,
     fetch.noSkip,
+    fetch.clear,
   ],
   responses: {
     "200": okStockList,

--- a/packages/rating-tracker-backend/src/openapi/paths/fetch/sustainalyticsEndpoint.ts
+++ b/packages/rating-tracker-backend/src/openapi/paths/fetch/sustainalyticsEndpoint.ts
@@ -21,6 +21,7 @@ const post: OpenAPIV3.OperationObject = {
         "If not present, all stocks known to the system will be used",
     },
     fetch.detach,
+    fetch.clear,
   ],
   responses: {
     "200": okStockList,

--- a/packages/rating-tracker-commons/src/lib/Currency.ts
+++ b/packages/rating-tracker-commons/src/lib/Currency.ts
@@ -132,7 +132,7 @@ export const currencyArray = [
   "SGD",
   "SHP",
   "SLE",
-  "SLL", // Ceases to be legal tender effective 1 April 2023
+  "SLL", // Ceases to be legal tender effective 1 January 2024
   "SOS",
   "SRD",
   "SSP",
@@ -334,7 +334,7 @@ export const currencyName: Record<Currency, string> = {
   SGD: "Singapore Dollar",
   SHP: "Saint Helena Pound",
   SLE: "Leone",
-  SLL: "Leone", // Ceases to be legal tender effective 1 April 2023
+  SLL: "Leone", // Ceases to be legal tender effective 1 January 2024
   SOS: "Somali Shilling",
   SRD: "Surinam Dollar",
   SSP: "South Sudanese Pound",

--- a/packages/rating-tracker-frontend/src/components/EditStock/index.tsx
+++ b/packages/rating-tracker-frontend/src/components/EditStock/index.tsx
@@ -8,6 +8,10 @@ import {
   Box,
   DialogActions,
   Button,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+  Divider,
 } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
 import PublishedWithChangesIcon from "@mui/icons-material/PublishedWithChanges";
@@ -47,6 +51,8 @@ const EditStock = (props: EditStockProps): JSX.Element => {
   const [countryError, setCountryError] = useState<boolean>(false); // Error in the country input field.
   // The value of the text field in the country autocomplete.
   const [countryInputValue, setCountryInputValue] = useState<string>(countryName[props.stock?.country]);
+  // Whether to clear information related to the data provider before fetching
+  const [clear, setClear] = useState<boolean>(false);
   const [morningstarID, setMorningstarID] = useState<string>(props.stock?.morningstarID);
   const [morningstarIDRequestInProgress, setMorningstarIDRequestInProgress] = useState<boolean>(false);
   const [marketScreenerID, setMarketScreenerID] = useState<string>(props.stock?.marketScreenerID);
@@ -89,7 +95,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             marketScreenerID: marketScreenerID !== props.stock.marketScreenerID ? marketScreenerID : undefined,
             msciID: msciID !== props.stock.msciID ? msciID : undefined,
             ric: ric !== props.stock.ric ? ric : undefined,
-            spID: spID !== props.stock.spID ? spID : undefined,
+            spID: spID !== props.stock.spID ? (spID === null ? "" : spID) : undefined,
             sustainalyticsID: sustainalyticsID !== props.stock.sustainalyticsID ? sustainalyticsID : undefined,
           },
         })
@@ -123,7 +129,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             // If a Morningstar ID was set, we fetch data from Morningstar using the new ID.
             axios
               .post(baseUrl + fetchMorningstarEndpointPath, undefined, {
-                params: { ticker: props.stock.ticker, noSkip: true },
+                params: { ticker: props.stock.ticker, noSkip: true, clear },
               })
               .then(() => {})
               .catch((e) => {
@@ -170,7 +176,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             // If a Market Screener ID was set, we fetch data from Market Screener using the new ID.
             axios
               .post(baseUrl + fetchMarketScreenerEndpointPath, undefined, {
-                params: { ticker: props.stock.ticker, noSkip: true },
+                params: { ticker: props.stock.ticker, noSkip: true, clear },
               })
               .then(() => {})
               .catch((e) => {
@@ -217,7 +223,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             // If an MSCI ID was set, we fetch data from MSCI using the new ID.
             axios
               .post(baseUrl + fetchMSCIEndpointPath, undefined, {
-                params: { ticker: props.stock.ticker, noSkip: true },
+                params: { ticker: props.stock.ticker, noSkip: true, clear },
               })
               .then(() => {})
               .catch((e) => {
@@ -264,7 +270,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             // If a RIC was set, we fetch data from Refinitiv using the new RIC.
             axios
               .post(baseUrl + fetchRefinitivEndpointPath, undefined, {
-                params: { ticker: props.stock.ticker, noSkip: true },
+                params: { ticker: props.stock.ticker, noSkip: true, clear },
               })
               .then(() => {})
               .catch((e) => {
@@ -311,7 +317,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             // If an S&P ID was set, we fetch data from S&P using the new ID.
             axios
               .post(baseUrl + fetchSPEndpointPath, undefined, {
-                params: { ticker: props.stock.ticker, noSkip: true },
+                params: { ticker: props.stock.ticker, noSkip: true, clear },
               })
               .then(() => {})
               .catch((e) => {
@@ -370,7 +376,7 @@ const EditStock = (props: EditStockProps): JSX.Element => {
             // If a Sustainalytics ID was set, we fetch data from Sustainalytics using the new ID.
             axios
               .post(baseUrl + fetchSustainalyticsEndpointPath, undefined, {
-                params: { ticker: props.stock.ticker },
+                params: { ticker: props.stock.ticker, clear },
               })
               .then(() => {})
               .catch((e) => {
@@ -463,6 +469,28 @@ const EditStock = (props: EditStockProps): JSX.Element => {
               disableClearable
               renderInput={(params) => <TextField {...params} label="Country" error={countryError} />}
             />
+          </Grid>
+          <Grid item xs={12}>
+            <Divider sx={{ my: 1, width: "100%" }} />
+          </Grid>
+          <Grid item xs={12}>
+            <FormGroup>
+              <FormControlLabel
+                sx={{ pb: 2 }}
+                control={<Checkbox checked={clear} onChange={() => setClear((prev) => !prev)} />}
+                label={
+                  <>
+                    <Typography variant="body1" fontWeight="bold" color="text.primary">
+                      Clear saved values
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      If an certain attribute value is no longer available, check this option before refetching to clear
+                      all attribute values available from the selected data provider.
+                    </Typography>
+                  </>
+                }
+              />
+            </FormGroup>
           </Grid>
           <Grid item xs={12} container spacing={1} alignItems="center">
             <Grid item width={{ xs: "100%", sm: "calc(100% - 175px)" }}>


### PR DESCRIPTION
* Add “Clear saved values” checkbox in Edit Stock dialog
* Extend Fetch API endpoints by `clear` parameter
* Initialize parameters with `null` or `undefined` in Fetch Controller based on `clear`
* Remove data from providers if ID is removed
* Extend test to validate values being removed if ID is removed
* Fix consistency of test
* Reset `sentMessages` array after unsafe tests
* Extend legal tender period of SLL