### PR TITLE
Improve fetchers

### DIFF
--- a/packages/rating-tracker-backend/src/fetchers/marketScreenerFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/marketScreenerFetcher.ts
@@ -59,7 +59,9 @@ const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stoc
     let analystTargetPrice: number = req.query.clear ? null : undefined;
 
     try {
-      await driver.get(`https://www.marketscreener.com/quote/stock/${stock.marketScreenerID}/`);
+      const url = `https://www.marketscreener.com/quote/stock/${stock.marketScreenerID}/`;
+      await driver.get(url);
+      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
       // Wait for most of the page to load for a maximum of 20 seconds.
       await driver.wait(until.elementLocated(By.id("zbCenter")), 20000);
 

--- a/packages/rating-tracker-backend/src/fetchers/morningstarFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/morningstarFetcher.ts
@@ -77,17 +77,14 @@ const morningstarFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>)
     let description: string = req.query.clear ? null : undefined;
 
     try {
-      await driver.get(
+      const url =
         `https://tools.morningstar.it/it/stockreport/default.aspx?Site=us&id=${stock.morningstarID}` +
-          `&LanguageId=en-US&SecurityToken=${stock.morningstarID}]3]0]E0WWE$$ALL`
-      );
+        `&LanguageId=en-US&SecurityToken=${stock.morningstarID}]3]0]E0WWE$$ALL`;
+      await driver.get(url);
+      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
       await driver.wait(
-        until.elementLocated(By.id("IntradayPriceSummary")),
-        20000 // Wait for most of the page to load for a maximum of 20 seconds.
-      );
-      await driver.wait(
-        until.elementLocated(By.id("CompanyProfile")),
-        10000 // Wait for the element to load for a maximum of 10 seconds.
+        until.elementLocated(By.css("#SnapshotBodyContent:has(#IntradayPriceSummary):has(#CompanyProfile)")),
+        30000 // Wait for the page to load for a maximum of 30 seconds.
       );
 
       // Prepare an error message header containing the stock name and ticker.

--- a/packages/rating-tracker-backend/src/fetchers/msciFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/msciFetcher.ts
@@ -53,9 +53,10 @@ const msciFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) => {
 
     try {
       await driver.manage().deleteAllCookies(); // Delete all cookies since MSCI allows only 4 requests per session.
-      await driver.get(
-        `https://www.msci.com/our-solutions/esg-investing/esg-ratings-climate-search-tool/issuer/${stock.msciID}`
-      );
+      const url =
+        "https://www.msci.com/our-solutions/esg-investing/esg-ratings-climate-search-tool/issuer/" + stock.msciID;
+      await driver.get(url);
+      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
       await driver.wait(
         until.elementsLocated(By.className("esg-expandable")),
         15000 // Wait for the page to load for a maximum of 15 seconds.

--- a/packages/rating-tracker-backend/src/fetchers/refinitivFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/refinitivFetcher.ts
@@ -54,7 +54,9 @@ const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) =
     try {
       // Delete all cookies since Refinitiv allows only 100 requests per session.
       await driver.manage().deleteAllCookies();
-      await driver.get(`https://www.refinitiv.com/bin/esg/esgsearchresult?ricCode=${stock.ric}`);
+      const url = `https://www.refinitiv.com/bin/esg/esgsearchresult?ricCode=${stock.ric}`;
+      await driver.get(url);
+      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
       // Wait for the page to load for a maximum of 5 seconds.
       await driver.wait(until.elementLocated(By.css("pre")), 5000);
 

--- a/packages/rating-tracker-backend/src/fetchers/spFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/spFetcher.ts
@@ -51,9 +51,11 @@ const spFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) => {
     let spESGScore: number = req.query.clear ? null : undefined;
 
     try {
-      await driver.get(`https://www.spglobal.com/esg/scores/results?cid=${stock.spID}`);
+      const url = `https://www.spglobal.com/esg/scores/results?cid=${stock.spID}`;
+      await driver.get(url);
+      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
       // Wait for the page to load for a maximum of 10 seconds.
-      await driver.wait(until.elementLocated(By.css("div.panel-set__first-column:has(h1#company-name)")), 10000);
+      await driver.wait(until.elementLocated(By.css("div.panel-set__first-column:has(h1#company-name)")), 15000);
 
       const lockedContent = await driver.findElements(By.className("lock__content"));
       if (

--- a/packages/rating-tracker-backend/src/utils/cron.ts
+++ b/packages/rating-tracker-backend/src/utils/cron.ts
@@ -23,7 +23,7 @@ const setupCronJobs = (bypassAuthenticationForInternalRequestsToken: string, aut
     autoFetchSchedule,
     async () => {
       await axios.post(`http://localhost:${process.env.PORT}/api${fetchSustainalyticsEndpointPath}`, undefined, {
-        params: { detach: "true" },
+        params: { detach: "false" },
         headers: {
           Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
         },

--- a/packages/rating-tracker-backend/src/utils/webdriver.ts
+++ b/packages/rating-tracker-backend/src/utils/webdriver.ts
@@ -36,6 +36,8 @@ export const getDriver = async (headless?: boolean, pageLoadStrategy?: PageLoadS
         .setBrowserName("chrome")
         // Do not wait for all resources to load. This speeds up the page load.
         .setPageLoadStrategy(pageLoadStrategy ?? "none")
+        // Silently dismiss all unexpected prompts
+        .setAlertBehavior("dismiss")
     )
     .setChromeOptions(options)
     .build()


### PR DESCRIPTION
* Check for correct window URL before evaluating content
* Wait for only one element on Morningstar pages
* Do not detach Sustainalytics Cron job request
* Silently dismiss all unexpected prompts