### PR TITLE
Fix and improve fetchers

### DIFF
--- a/Dockerfile-yarn
+++ b/Dockerfile-yarn
@@ -4,8 +4,8 @@ ENV FORCE_COLOR true
 WORKDIR /workdir
 
 # Copy files required for installing dependencies
-COPY .yarn ./.yarn
 COPY global ./global
+COPY .yarn ./.yarn
 COPY package.json .yarnrc.yml yarn.lock ./
 COPY packages/rating-tracker-backend/package.json ./packages/rating-tracker-backend/
 COPY packages/rating-tracker-commons/package.json ./packages/rating-tracker-commons/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,7 @@ node {
             docker rmi $imagename:build-$GIT_COMMIT_HASH-test || true
             docker rmi $imagename:build-$GIT_COMMIT_HASH || true
             docker image prune --filter label=stage=build -f
+            docker builder prune -f --keep-storage 1G
             rm -r global
             """
         }

--- a/packages/rating-tracker-backend/src/controllers/FetchController.ts
+++ b/packages/rating-tracker-backend/src/controllers/FetchController.ts
@@ -39,6 +39,7 @@ const URL_SUSTAINALYTICS = "https://www.sustainalytics.com/sustapi/companyrating
  */
 export type FetcherWorkspace<T> = {
   queued: T[];
+  skipped: T[];
   successful: T[];
   failed: T[];
 };
@@ -127,11 +128,18 @@ export class FetchController {
 
     const stocks: FetcherWorkspace<Stock> = {
       queued: [...stockList],
+      skipped: [],
       successful: [],
       failed: [],
     };
 
+    logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from Morningstar.`);
     await Promise.all([...Array(determineConcurrency(req))].map(() => morningstarFetcher(req, stocks)));
+    logger.info(PREFIX_SELENIUM + `Done fetching stocks from Morningstar.`);
+    stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
+    stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
+    stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
+    stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
     if (stocks.successful.length === 0) {
       res.status(204).end();
@@ -192,11 +200,18 @@ export class FetchController {
 
     const stocks: FetcherWorkspace<Stock> = {
       queued: [...stockList],
+      skipped: [],
       successful: [],
       failed: [],
     };
 
+    logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from MarketScreener.`);
     await Promise.all([...Array(determineConcurrency(req))].map(() => marketScreenerFetcher(req, stocks)));
+    logger.info(PREFIX_SELENIUM + `Done fetching stocks from MarketScreener.`);
+    stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
+    stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
+    stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
+    stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
     if (stocks.successful.length === 0) {
       res.status(204).end();
@@ -257,11 +272,18 @@ export class FetchController {
 
     const stocks: FetcherWorkspace<Stock> = {
       queued: [...stockList],
+      skipped: [],
       successful: [],
       failed: [],
     };
 
+    logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from MSCI.`);
     await Promise.all([...Array(determineConcurrency(req))].map(() => msciFetcher(req, stocks)));
+    logger.info(PREFIX_SELENIUM + `Done fetching stocks from MSCI.`);
+    stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
+    stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
+    stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
+    stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
     if (stocks.successful.length === 0) {
       res.status(204).end();
@@ -322,11 +344,18 @@ export class FetchController {
 
     const stocks: FetcherWorkspace<Stock> = {
       queued: [...stockList],
+      skipped: [],
       successful: [],
       failed: [],
     };
 
+    logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from Refinitiv.`);
     await Promise.all([...Array(determineConcurrency(req))].map(() => refinitivFetcher(req, stocks)));
+    logger.info(PREFIX_SELENIUM + `Done fetching stocks from Refinitiv.`);
+    stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
+    stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
+    stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
+    stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
     if (stocks.successful.length === 0) {
       res.status(204).end();
@@ -387,11 +416,18 @@ export class FetchController {
 
     const stocks: FetcherWorkspace<Stock> = {
       queued: [...stockList],
+      skipped: [],
       successful: [],
       failed: [],
     };
 
+    logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from S&P.`);
     await Promise.all([...Array(determineConcurrency(req))].map(() => spFetcher(req, stocks)));
+    logger.info(PREFIX_SELENIUM + `Done fetching stocks from S&P.`);
+    stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
+    stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
+    stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
+    stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
     if (stocks.successful.length === 0) {
       res.status(204).end();
@@ -569,17 +605,17 @@ export class FetchController {
         }
       }
       if (errorCount >= 10) {
-        // If we have 10 errors, we stop fetching data, since something is probably wrong.
+        // If we have 10 errors, we stop extracting data, since something is probably wrong.
         logger.error(
           PREFIX_SELENIUM +
             chalk.redBright(
-              `Aborting extracting information from Sustainalytics after ${successfulCount} successful fetches ` +
+              `Aborting extracting information from Sustainalytics after ${successfulCount} successful extractions ` +
                 `and ${errorCount} failures. Will continue next time.`
             )
         );
         await signal.sendMessage(
           SIGNAL_PREFIX_ERROR +
-            `Aborting extracting information from Sustainalytics after ${successfulCount} successful fetches ` +
+            `Aborting extracting information from Sustainalytics after ${successfulCount} successful extractions ` +
             `and ${errorCount} failures. Will continue next time.`,
           "fetchError"
         );

--- a/packages/rating-tracker-backend/src/fetchers/marketScreenerFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/marketScreenerFetcher.ts
@@ -2,7 +2,7 @@
 /* istanbul ignore file -- @preserve */
 import { Request } from "express";
 import { FetcherWorkspace } from "../controllers/FetchController.js";
-import { getDriver, quitDriver, takeScreenshot } from "../utils/webdriver.js";
+import { getDriver, openPageAndWait, quitDriver, takeScreenshot } from "../utils/webdriver.js";
 import logger, { PREFIX_SELENIUM } from "../utils/logger.js";
 import { formatDistance } from "date-fns";
 import { Stock } from "rating-tracker-commons";
@@ -27,9 +27,11 @@ const XPATH_SPREAD_AVERAGE_TARGET =
  * with errors)
  * @throws an {@link APIError} in case of a severe error
  */
-const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) => {
+const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>): Promise<void> => {
   // Acquire a new session
   const driver = await getDriver(true);
+  const sessionID = (await driver.getSession()).getId();
+
   // Work while stocks are in the queue
   while (stocks.queued.length) {
     // Get the first stock in the queue
@@ -52,6 +54,7 @@ const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stoc
             { addSuffix: true }
           )}`
       );
+      stocks.skipped.push(stock);
       continue;
     }
     let analystConsensus: number = req.query.clear ? null : undefined;
@@ -60,8 +63,13 @@ const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stoc
 
     try {
       const url = `https://www.marketscreener.com/quote/stock/${stock.marketScreenerID}/`;
-      await driver.get(url);
-      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
+      const driverHealthy = await openPageAndWait(driver, url);
+      // When we were unable to open the page, we assume the driver is unhealthy and end.
+      if (!driverHealthy) {
+        // Have another driver attempt the fetch of the current stock
+        stocks.queued.push(stock);
+        break;
+      }
       // Wait for most of the page to load for a maximum of 20 seconds.
       await driver.wait(until.elementLocated(By.id("zbCenter")), 20000);
 
@@ -196,7 +204,7 @@ const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stoc
       stocks.failed.push(stock);
       if (req.query.ticker) {
         // If this request was for a single stock, we shut down the driver and throw an error.
-        await quitDriver(driver);
+        await quitDriver(driver, sessionID);
         throw new APIError(
           502,
           `Stock ${stock.ticker}: Unable to fetch MarketScreener data: ${String(e.message).split(/[\n:{]/)[0]}`
@@ -230,13 +238,15 @@ const marketScreenerFetcher = async (req: Request, stocks: FetcherWorkspace<Stoc
             `successful fetches and ${stocks.failed.length} failures. Will continue next time.`,
           "fetchError"
         );
+        const skippedStocks = [...stocks.queued];
         stocks.queued.length = 0;
+        skippedStocks.forEach((skippedStock) => stocks.skipped.push(skippedStock));
       }
       break;
     }
   }
   // The queue is now empty, we end the session.
-  await quitDriver(driver);
+  await quitDriver(driver, sessionID);
 };
 
 export default marketScreenerFetcher;

--- a/packages/rating-tracker-backend/src/fetchers/refinitivFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/refinitivFetcher.ts
@@ -2,7 +2,7 @@
 /* istanbul ignore file -- @preserve */
 import { Request } from "express";
 import { FetcherWorkspace } from "../controllers/FetchController.js";
-import { getDriver, quitDriver, takeScreenshot } from "../utils/webdriver.js";
+import { getDriver, openPageAndWait, quitDriver, takeScreenshot } from "../utils/webdriver.js";
 import logger, { PREFIX_SELENIUM } from "../utils/logger.js";
 import { formatDistance } from "date-fns";
 import { Stock } from "rating-tracker-commons";
@@ -21,9 +21,11 @@ import APIError from "../utils/apiError.js";
  * with errors)
  * @throws an {@link APIError} in case of a severe error
  */
-const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) => {
+const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>): Promise<void> => {
   // Acquire a new session
   const driver = await getDriver(true);
+  const sessionID = (await driver.getSession()).getId();
+
   // Work while stocks are in the queue
   while (stocks.queued.length) {
     // Get the first stock in the queue
@@ -46,6 +48,7 @@ const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) =
             { addSuffix: true }
           )}`
       );
+      stocks.skipped.push(stock);
       continue;
     }
     let refinitivESGScore: number = req.query.clear ? null : undefined;
@@ -55,8 +58,13 @@ const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) =
       // Delete all cookies since Refinitiv allows only 100 requests per session.
       await driver.manage().deleteAllCookies();
       const url = `https://www.refinitiv.com/bin/esg/esgsearchresult?ricCode=${stock.ric}`;
-      await driver.get(url);
-      await driver.wait(until.urlIs(url)); // Wait until URL is present and previous content is removed.
+      const driverHealthy = await openPageAndWait(driver, url);
+      // When we were unable to open the page, we assume the driver is unhealthy and end.
+      if (!driverHealthy) {
+        // Have another driver attempt the fetch of the current stock
+        stocks.queued.push(stock);
+        break;
+      }
       // Wait for the page to load for a maximum of 5 seconds.
       await driver.wait(until.elementLocated(By.css("pre")), 5000);
 
@@ -136,7 +144,7 @@ const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) =
       stocks.failed.push(stock);
       if (req.query.ticker) {
         // If this request was for a single stock, we shut down the driver and throw an error.
-        await quitDriver(driver);
+        await quitDriver(driver, sessionID);
         throw new APIError(
           (e as Error).message.includes("Limit exceeded") ? 429 : 502,
           `Stock ${stock.ticker}: Unable to fetch Refinitiv information: ${String(e.message).split(/[\n:{]/)[0]}`
@@ -187,13 +195,15 @@ const refinitivFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>) =
             `successful fetches and ${stocks.failed.length} failures. Will continue next time.`,
           "fetchError"
         );
+        const skippedStocks = [...stocks.queued];
         stocks.queued.length = 0;
+        skippedStocks.forEach((skippedStock) => stocks.skipped.push(skippedStock));
       }
       break;
     }
   }
   // The queue is now empty, we end the session.
-  await quitDriver(driver);
+  await quitDriver(driver, sessionID);
 };
 
 export default refinitivFetcher;

--- a/packages/rating-tracker-backend/src/utils/logger.ts
+++ b/packages/rating-tracker-backend/src/utils/logger.ts
@@ -11,6 +11,7 @@ import { stockLogoEndpointPath } from "rating-tracker-commons";
 
 dotenv.config();
 
+export const PREFIX_CRON = chalk.whiteBright.bgGrey(" \ufba7 ") + chalk.grey(" ");
 export const PREFIX_NODEJS = chalk.whiteBright.bgHex("#339933")(" \uf898 ") + chalk.hex("#339933")(" ");
 export const PREFIX_REDIS = chalk.whiteBright.bgHex("#D82C20")(" \ue76d ") + chalk.hex("#D82C20")(" ");
 export const PREFIX_POSTGRES = chalk.whiteBright.bgHex("#336791")(" \ue76e ") + chalk.hex("#336791")(" ");
@@ -18,7 +19,7 @@ export const PREFIX_SELENIUM = chalk.whiteBright.bgHex("#43B02A")(" \ufc0d ") + 
 export const PREFIX_SIGNAL = chalk.whiteBright.bgHex("#4975E8")(" \uf868 ") + chalk.hex("#4975E8")(" ");
 
 const levelIcons = {
-  10: chalk.gray(" \uf002 "),
+  10: chalk.grey(" \uf002 "),
   20: chalk.blue(" \uf188 "),
   30: chalk.cyanBright(" \uf7fc "),
   40: chalk.yellowBright(" \uf071 "),

--- a/packages/rating-tracker-commons/tsconfig.json
+++ b/packages/rating-tracker-commons/tsconfig.json
@@ -5,6 +5,5 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
* Add timeout to URL wait condition
* Discard of unhealthy WebDriver sessions and retry their stock in progress
* Attempt forceful shutdown of stale sessions
* Maintain list of skipped stocks
* Print number of successful, skipped, still queued and failed stocks after fetching
* Catch `AxiosErrors` in Cron jobs

* Clear build cache in `Jenkinsfile`
* Optimize `Dockerfile-yarn` for caching
* Fix eslint errors