### PR TITLE
Improve fetchers

### DIFF
--- a/packages/rating-tracker-backend/src/controllers/FetchController.ts
+++ b/packages/rating-tracker-backend/src/controllers/FetchController.ts
@@ -132,14 +132,25 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from Morningstar.`);
-    await Promise.all([...Array(determineConcurrency(req))].map(() => morningstarFetcher(req, stocks)));
+    const results = await Promise.allSettled(
+      [...Array(determineConcurrency(req))].map(() => morningstarFetcher(req, stocks))
+    );
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from Morningstar.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
     stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
     stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
-    if (stocks.successful.length === 0) {
+    // If stocks are still queued, something went wrong and we send an error response.
+    if (stocks.queued.length) {
+      // If fetchers threw an error, we rethrow the first one
+      const firstRejection: PromiseRejectedResult | undefined = results
+        .filter((result) => result.status === "rejected")
+        .pop() as PromiseRejectedResult;
+      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from Morningstar.");
+    }
+
+    if (!stocks.successful.length) {
       res.status(204).end();
     } else {
       res.status(200).json(stocks.successful).end();
@@ -203,14 +214,27 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from MarketScreener.`);
-    await Promise.all([...Array(determineConcurrency(req))].map(() => marketScreenerFetcher(req, stocks)));
+    const results = await Promise.allSettled(
+      [...Array(determineConcurrency(req))].map(() => marketScreenerFetcher(req, stocks))
+    );
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from MarketScreener.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
     stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
     stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
-    if (stocks.successful.length === 0) {
+    // If stocks are still queued, something went wrong and we send an error response.
+    if (stocks.queued.length) {
+      // If fetchers threw an error, we rethrow the first one
+      const firstRejection: PromiseRejectedResult | undefined = results
+        .filter((result) => result.status === "rejected")
+        .pop() as PromiseRejectedResult;
+      throw (
+        firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from MarketScreener.")
+      );
+    }
+
+    if (!stocks.successful.length) {
       res.status(204).end();
     } else {
       res.status(200).json(stocks.successful).end();
@@ -274,14 +298,23 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from MSCI.`);
-    await Promise.all([...Array(determineConcurrency(req))].map(() => msciFetcher(req, stocks)));
+    const results = await Promise.allSettled([...Array(determineConcurrency(req))].map(() => msciFetcher(req, stocks)));
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from MSCI.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
     stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
     stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
-    if (stocks.successful.length === 0) {
+    // If stocks are still queued, something went wrong and we send an error response.
+    if (stocks.queued.length) {
+      // If fetchers threw an error, we rethrow the first one
+      const firstRejection: PromiseRejectedResult | undefined = results
+        .filter((result) => result.status === "rejected")
+        .pop() as PromiseRejectedResult;
+      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from MSCI.");
+    }
+
+    if (!stocks.successful.length) {
       res.status(204).end();
     } else {
       res.status(200).json(stocks.successful);
@@ -345,14 +378,25 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from Refinitiv.`);
-    await Promise.all([...Array(determineConcurrency(req))].map(() => refinitivFetcher(req, stocks)));
+    const results = await Promise.allSettled(
+      [...Array(determineConcurrency(req))].map(() => refinitivFetcher(req, stocks))
+    );
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from Refinitiv.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
     stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
     stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
-    if (stocks.successful.length === 0) {
+    // If stocks are still queued, something went wrong and we send an error response.
+    if (stocks.queued.length) {
+      // If fetchers threw an error, we rethrow the first one
+      const firstRejection: PromiseRejectedResult | undefined = results
+        .filter((result) => result.status === "rejected")
+        .pop() as PromiseRejectedResult;
+      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from Refinitiv.");
+    }
+
+    if (!stocks.successful.length) {
       res.status(204).end();
     } else {
       res.status(200).json(stocks.successful).end();
@@ -416,14 +460,23 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from S&P.`);
-    await Promise.all([...Array(determineConcurrency(req))].map(() => spFetcher(req, stocks)));
+    const results = await Promise.allSettled([...Array(determineConcurrency(req))].map(() => spFetcher(req, stocks)));
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from S&P.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
     stocks.skipped.length && logger.info(PREFIX_SELENIUM + `  Skipped: ${stocks.skipped.length}`);
     stocks.queued.length && logger.info(PREFIX_SELENIUM + `  Still queued: ${stocks.queued.length}`);
 
-    if (stocks.successful.length === 0) {
+    // If stocks are still queued, something went wrong and we send an error response.
+    if (stocks.queued.length) {
+      // If fetchers threw an error, we rethrow the first one
+      const firstRejection: PromiseRejectedResult | undefined = results
+        .filter((result) => result.status === "rejected")
+        .pop() as PromiseRejectedResult;
+      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from S&P.");
+    }
+
+    if (!stocks.successful.length) {
       res.status(204).end();
     } else {
       res.status(200).json(stocks.successful).end();

--- a/packages/rating-tracker-backend/src/utils/cron.ts
+++ b/packages/rating-tracker-backend/src/utils/cron.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file -- @preserve */ // We do not test Cron jobs
 import * as cron from "cron";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import {
   fetchMarketScreenerEndpointPath,
   fetchMorningstarEndpointPath,
@@ -11,6 +11,7 @@ import {
 } from "rating-tracker-commons";
 import chalk from "chalk";
 import logger, { PREFIX_CRON } from "./logger.js";
+import { sendMessage } from "../signal/signal.js";
 
 /**
  * Creates Cron jobs for regular fetching from data providers.
@@ -29,7 +30,13 @@ const setupCronJobs = (bypassAuthenticationForInternalRequestsToken: string, aut
             Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
           },
         })
-        .catch((e) => logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the MSCI Cron Job: ${e}`)));
+        .catch((e: AxiosError) => {
+          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the MSCI Cron Job: ${e}`));
+          sendMessage(
+            `An error occurred during the MSCI Cron Job: ${String(e.message).split(/[\n:{]/)[0]}`,
+            "fetchError"
+          );
+        });
       await axios
         .post(`http://localhost:${process.env.PORT}/api${fetchRefinitivEndpointPath}`, undefined, {
           params: { detach: "false", concurrency: process.env.SELENIUM_MAX_CONCURRENCY },
@@ -37,9 +44,13 @@ const setupCronJobs = (bypassAuthenticationForInternalRequestsToken: string, aut
             Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
           },
         })
-        .catch((e) =>
-          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the Refinitiv Cron Job: ${e}`))
-        );
+        .catch((e: AxiosError) => {
+          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the Refinitiv Cron Job: ${e}`));
+          sendMessage(
+            `An error occurred during the Refinitiv Cron Job: ${String(e.message).split(/[\n:{]/)[0]}`,
+            "fetchError"
+          );
+        });
       await axios
         .post(`http://localhost:${process.env.PORT}/api${fetchSPEndpointPath}`, undefined, {
           params: { detach: "false", concurrency: process.env.SELENIUM_MAX_CONCURRENCY },
@@ -47,7 +58,13 @@ const setupCronJobs = (bypassAuthenticationForInternalRequestsToken: string, aut
             Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
           },
         })
-        .catch((e) => logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the S&P Cron Job: ${e}`)));
+        .catch((e: AxiosError) => {
+          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the S&P Cron Job: ${e}`));
+          sendMessage(
+            `An error occurred during the S&P Cron Job: ${String(e.message).split(/[\n:{]/)[0]}`,
+            "fetchError"
+          );
+        });
       await axios
         .post(`http://localhost:${process.env.PORT}/api${fetchSustainalyticsEndpointPath}`, undefined, {
           params: { detach: "false" },
@@ -55,20 +72,28 @@ const setupCronJobs = (bypassAuthenticationForInternalRequestsToken: string, aut
             Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
           },
         })
-        .catch((e) =>
-          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the Sustainalytics Cron Job: ${e}`))
-        );
+        .catch((e: AxiosError) => {
+          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the Sustainalytics Cron Job: ${e}`));
+          sendMessage(
+            `An error occurred during the Sustainalytics Cron Job: ${String(e.message).split(/[\n:{]/)[0]}`,
+            "fetchError"
+          );
+        });
       // Fetch data from Morningstar first
       await axios
         .post(`http://localhost:${process.env.PORT}/api${fetchMorningstarEndpointPath}`, undefined, {
-          params: { detach: "false", concurrency: process.env.SELENIUM_MAX_CONCURRENCY },
+          params: { noSkip: "true", detach: "false", concurrency: process.env.SELENIUM_MAX_CONCURRENCY },
           headers: {
             Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
           },
         })
-        .catch((e) =>
-          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the Morningstar Cron Job: ${e}`))
-        );
+        .catch((e: AxiosError) => {
+          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the Morningstar Cron Job: ${e}`));
+          sendMessage(
+            `An error occurred during the Morningstar Cron Job: ${String(e.message).split(/[\n:{]/)[0]}`,
+            "fetchError"
+          );
+        });
       // Fetch data from Marketscreener after Morningstar, so Market Screener can use the up-to-date Last Close price to
       // calculate the analyst target price properly
       await axios
@@ -78,9 +103,13 @@ const setupCronJobs = (bypassAuthenticationForInternalRequestsToken: string, aut
             Cookie: `bypassAuthenticationForInternalRequestsToken=${bypassAuthenticationForInternalRequestsToken};`,
           },
         })
-        .catch((e) =>
-          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the MarketScreener Cron Job: ${e}`))
-        );
+        .catch((e: AxiosError) => {
+          logger.error(PREFIX_CRON + chalk.redBright(`An error occurred during the MarketScreener Cron Job: ${e}`));
+          sendMessage(
+            `An error occurred during the MarketScreener Cron Job: ${String(e.message).split(/[\n:{]/)[0]}`,
+            "fetchError"
+          );
+        });
     },
     null,
     true

--- a/packages/rating-tracker-backend/src/utils/webdriver.ts
+++ b/packages/rating-tracker-backend/src/utils/webdriver.ts
@@ -22,6 +22,8 @@ type PageLoadStrategy = "normal" | "eager" | "none";
  * @throws an {@link APIError} if the WebDriver cannot be created
  */
 export const getDriver = async (headless?: boolean, pageLoadStrategy?: PageLoadStrategy): Promise<WebDriver> => {
+  // Wait up to 1 second randomly to avoid a not yet identified bottleneck
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), Math.random() * 1000));
   const url = process.env.SELENIUM_URL;
   const options = new chrome.Options()
     .addArguments("window-size=1080x3840") // convenient for screenshots


### PR DESCRIPTION
* Wait up to 1 second randomly before requesting a WebDriver session to avoid a not yet identified bottleneck
* Send a Signal message for AxiosErrors from Cron jobs
* Use `Promise.allSettled(…)` for workers to collect errors instead of rejecting after the first one
* Throw an error if stocks are still queued after all fetchers are done