### PR TITLE
Improve fetchers

### DIFF
--- a/packages/rating-tracker-backend/src/controllers/FetchController.ts
+++ b/packages/rating-tracker-backend/src/controllers/FetchController.ts
@@ -134,9 +134,9 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from Morningstar.`);
-    const results = await Promise.allSettled(
-      [...Array(determineConcurrency(req))].map(() => morningstarFetcher(req, stocks))
-    );
+    const rejectedResult = (
+      await Promise.allSettled([...Array(determineConcurrency(req))].map(() => morningstarFetcher(req, stocks)))
+    ).find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from Morningstar.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
@@ -146,10 +146,12 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      const firstRejection: PromiseRejectedResult | undefined = results
-        .filter((result) => result.status === "rejected")
-        .pop() as PromiseRejectedResult;
-      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from Morningstar.");
+      throw rejectedResult?.reason ?? new APIError(500, "An unknown error occurred while fetching from Morningstar.");
+    }
+
+    // If this request was for a single stock and an error occurred, we rethrow that error
+    if (req.query.ticker && rejectedResult) {
+      throw rejectedResult.reason;
     }
 
     if (!stocks.successful.length) {
@@ -217,9 +219,9 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from MarketScreener.`);
-    const results = await Promise.allSettled(
-      [...Array(determineConcurrency(req))].map(() => marketScreenerFetcher(req, stocks))
-    );
+    const rejectedResult = (
+      await Promise.allSettled([...Array(determineConcurrency(req))].map(() => marketScreenerFetcher(req, stocks)))
+    ).find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from MarketScreener.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
@@ -229,12 +231,14 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      const firstRejection: PromiseRejectedResult | undefined = results
-        .filter((result) => result.status === "rejected")
-        .pop() as PromiseRejectedResult;
       throw (
-        firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from MarketScreener.")
+        rejectedResult?.reason ?? new APIError(500, "An unknown error occurred while fetching from MarketScreener.")
       );
+    }
+
+    // If this request was for a single stock and an error occurred, we rethrow that error
+    if (req.query.ticker && rejectedResult) {
+      throw rejectedResult.reason;
     }
 
     if (!stocks.successful.length) {
@@ -302,7 +306,9 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from MSCI.`);
-    const results = await Promise.allSettled([...Array(determineConcurrency(req))].map(() => msciFetcher(req, stocks)));
+    const rejectedResult = (
+      await Promise.allSettled([...Array(determineConcurrency(req))].map(() => msciFetcher(req, stocks)))
+    ).find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from MSCI.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
@@ -312,10 +318,12 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      const firstRejection: PromiseRejectedResult | undefined = results
-        .filter((result) => result.status === "rejected")
-        .pop() as PromiseRejectedResult;
-      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from MSCI.");
+      throw rejectedResult?.reason ?? new APIError(500, "An unknown error occurred while fetching from MSCI.");
+    }
+
+    // If this request was for a single stock and an error occurred, we rethrow that error
+    if (req.query.ticker && rejectedResult) {
+      throw rejectedResult.reason;
     }
 
     if (!stocks.successful.length) {
@@ -383,9 +391,9 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from Refinitiv.`);
-    const results = await Promise.allSettled(
-      [...Array(determineConcurrency(req))].map(() => refinitivFetcher(req, stocks))
-    );
+    const rejectedResult = (
+      await Promise.allSettled([...Array(determineConcurrency(req))].map(() => refinitivFetcher(req, stocks)))
+    ).find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from Refinitiv.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
@@ -395,10 +403,12 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      const firstRejection: PromiseRejectedResult | undefined = results
-        .filter((result) => result.status === "rejected")
-        .pop() as PromiseRejectedResult;
-      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from Refinitiv.");
+      throw rejectedResult?.reason ?? new APIError(500, "An unknown error occurred while fetching from Refinitiv.");
+    }
+
+    // If this request was for a single stock and an error occurred, we rethrow that error
+    if (req.query.ticker && rejectedResult) {
+      throw rejectedResult.reason;
     }
 
     if (!stocks.successful.length) {
@@ -466,7 +476,9 @@ export class FetchController {
     };
 
     logger.info(PREFIX_SELENIUM + `Fetching ${stocks.queued.length} stocks from S&P.`);
-    const results = await Promise.allSettled([...Array(determineConcurrency(req))].map(() => spFetcher(req, stocks)));
+    const rejectedResult = (
+      await Promise.allSettled([...Array(determineConcurrency(req))].map(() => spFetcher(req, stocks)))
+    ).find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     logger.info(PREFIX_SELENIUM + `Done fetching stocks from S&P.`);
     stocks.successful.length && logger.info(PREFIX_SELENIUM + `  Successful: ${stocks.successful.length}`);
     stocks.failed.length && logger.info(PREFIX_SELENIUM + `  Failed: ${stocks.failed.length}`);
@@ -476,10 +488,12 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      const firstRejection: PromiseRejectedResult | undefined = results
-        .filter((result) => result.status === "rejected")
-        .pop() as PromiseRejectedResult;
-      throw firstRejection?.reason ?? new APIError(500, "An unknown error occurred while fetching from S&P.");
+      throw rejectedResult?.reason ?? new APIError(500, "An unknown error occurred while fetching from S&P.");
+    }
+
+    // If this request was for a single stock and an error occurred, we rethrow that error
+    if (req.query.ticker && rejectedResult) {
+      throw rejectedResult.reason;
     }
 
     if (!stocks.successful.length) {

--- a/packages/rating-tracker-backend/src/fetchers/msciFetcher.ts
+++ b/packages/rating-tracker-backend/src/fetchers/msciFetcher.ts
@@ -23,7 +23,7 @@ import APIError from "../utils/apiError.js";
  */
 const msciFetcher = async (req: Request, stocks: FetcherWorkspace<Stock>): Promise<void> => {
   // Acquire a new session
-  const driver = await getDriver(false, "eager");
+  const driver = await getDriver(true, "eager");
   const sessionID = (await driver.getSession()).getId();
 
   // Work while stocks are in the queue

--- a/packages/rating-tracker-backend/src/utils/webdriver.ts
+++ b/packages/rating-tracker-backend/src/utils/webdriver.ts
@@ -29,7 +29,7 @@ export const getDriver = async (headless?: boolean, pageLoadStrategy?: PageLoadS
   const options = new chrome.Options()
     .addArguments("window-size=1080x3840") // convenient for screenshots
     .addArguments("--blink-settings=imagesEnabled=false"); // Do not load images
-  headless && options.headless(); // In headless mode, the browser window is not shown.
+  headless && options.addArguments("--headless=new"); // In headless mode, the browser window is not shown.
 
   return await new Builder()
     .usingServer(url)


### PR DESCRIPTION
* Rethrow errors of fetcher if the request was for a single stock
* Use `--headless=new`
* Use new headless Chrome with MSCI