### PR TITLE
Remove error messages ending after “https:”

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "8.45.0-sdk",
+  "version": "8.46.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/packages/backend/src/controllers/FetchController.ts
+++ b/packages/backend/src/controllers/FetchController.ts
@@ -145,7 +145,15 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      throw rejectedResult?.reason ?? new APIError(500, "Morningstar fetchers exited with non-empty queue.");
+      throw (
+        rejectedResult?.reason ??
+        new APIError(
+          500,
+          `Morningstar fetchers exited with stocks ${stocks.queued
+            .map((stock) => stock.ticker)
+            .join(", ")} still queued.`,
+        )
+      );
     }
 
     // If this request was for a single stock and an error occurred, we rethrow that error
@@ -230,7 +238,15 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      throw rejectedResult?.reason ?? new APIError(500, "MarketScreener fetchers exited with non-empty queue.");
+      throw (
+        rejectedResult?.reason ??
+        new APIError(
+          500,
+          `MarketScreener fetchers exited with stocks ${stocks.queued
+            .map((stock) => stock.ticker)
+            .join(", ")} still queued.`,
+        )
+      );
     }
 
     // If this request was for a single stock and an error occurred, we rethrow that error
@@ -315,7 +331,13 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      throw rejectedResult?.reason ?? new APIError(500, "MSCI fetchers exited with non-empty queue.");
+      throw (
+        rejectedResult?.reason ??
+        new APIError(
+          500,
+          `MSCI fetchers exited with stocks ${stocks.queued.map((stock) => stock.ticker).join(", ")} still queued.`,
+        )
+      );
     }
 
     // If this request was for a single stock and an error occurred, we rethrow that error
@@ -400,7 +422,15 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      throw rejectedResult?.reason ?? new APIError(500, "Refinitiv fetchers exited with non-empty queue.");
+      throw (
+        rejectedResult?.reason ??
+        new APIError(
+          500,
+          `Refinitiv fetchers exited with stocks ${stocks.queued
+            .map((stock) => stock.ticker)
+            .join(", ")} still queued.`,
+        )
+      );
     }
 
     // If this request was for a single stock and an error occurred, we rethrow that error
@@ -485,7 +515,13 @@ export class FetchController {
     // If stocks are still queued, something went wrong and we send an error response.
     if (stocks.queued.length) {
       // If fetchers threw an error, we rethrow the first one
-      throw rejectedResult?.reason ?? new APIError(500, "S&P fetchers exited with non-empty queue.");
+      throw (
+        rejectedResult?.reason ??
+        new APIError(
+          500,
+          `S&P fetchers exited with stocks ${stocks.queued.map((stock) => stock.ticker).join(", ")} still queued.`,
+        )
+      );
     }
 
     // If this request was for a single stock and an error occurred, we rethrow that error

--- a/packages/backend/src/utils/webdriver.ts
+++ b/packages/backend/src/utils/webdriver.ts
@@ -7,8 +7,6 @@ import chalk from "chalk";
 import { Stock, resourceEndpointPath } from "@rating-tracker/commons";
 import { createResource } from "../redis/repositories/resourceRepository.js";
 import axios, { AxiosError } from "axios";
-import * as signal from "../signal/signal.js";
-import { SIGNAL_PREFIX_ERROR } from "../signal/signal.js";
 
 /**
  * A page load strategy to use by the WebDriver.
@@ -83,12 +81,6 @@ export const openPageAndWait = async (driver: WebDriver, url: string): Promise<b
     return true;
   } catch (e) {
     logger.error(PREFIX_SELENIUM + chalk.redBright(`Unable to fetch from page ${url} (driver may be unhealthy): ${e}`));
-    await signal.sendMessage(
-      SIGNAL_PREFIX_ERROR +
-        `Unable to fetch from page ${url} (driver may be unhealthy): ${String(e.message).split(/[\n:{]/)[0]}`,
-      "fetchError",
-    );
-
     return false;
   }
 };


### PR DESCRIPTION
* Add stock tickers to APIError message when ending with non-empty queue