### PR TITLE
Fix log level of stock logo requests

### DIFF
--- a/packages/backend/src/utils/logger.ts
+++ b/packages/backend/src/utils/logger.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-import { baseURL, stockLogoEndpointSuffix } from "@rating-tracker/commons";
+import { baseURL, stockLogoEndpointSuffix, stocksEndpointPath } from "@rating-tracker/commons";
 import cron from "cron";
 import { Request, Response } from "express";
 import pino from "pino";
@@ -84,7 +84,12 @@ new cron.CronJob(
  * @returns {void}
  */
 export const logRequest = (req: Request, res: Response, time: number): void =>
-  logger[req.originalUrl.startsWith(`${baseURL}${stockLogoEndpointSuffix}`) || req.ip === "::1" ? "trace" : "info"](
+  logger[
+    (req.originalUrl.startsWith(baseURL + stocksEndpointPath) && req.originalUrl.startsWith(stockLogoEndpointSuffix)) ||
+    req.ip === "::1"
+      ? "trace"
+      : "info"
+  ](
     {
       prefix: "nodejs",
       req: {


### PR DESCRIPTION
This pull request fixes the log level of stock logo requests in the server. Previously, all requests were logged as `info`, but now requests to the stock logo endpoint are logged as `trace`.