### PR TITLE
Fix log level of stock logo requests

### DIFF
--- a/packages/backend/src/utils/logger.ts
+++ b/packages/backend/src/utils/logger.ts
@@ -85,7 +85,7 @@ new cron.CronJob(
  */
 export const logRequest = (req: Request, res: Response, time: number): void =>
   logger[
-    (req.originalUrl.startsWith(baseURL + stocksEndpointPath) && req.originalUrl.startsWith(stockLogoEndpointSuffix)) ||
+    (req.originalUrl.startsWith(baseURL + stocksEndpointPath) && req.path.endsWith(stockLogoEndpointSuffix)) ||
     req.ip === "::1"
       ? "trace"
       : "info"


### PR DESCRIPTION
This pull request actually fixes the log level of stock logo requests in the server. Previously, all requests were logged as `info`, but now requests to the stock logo endpoint are logged as `trace`.