### PR TITLE
Improve frontend meta information

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,0 @@
-# .prettierignore file
-packages/*/coverage
-packages/*/dist
-.yarn/
-README.md
-
-packages/frontend/public/index.css

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 120,
-  "tabWidth": 2,
-  "useTabs": false
-}

--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "node": true
   },
-  "extends": ["plugin:jsdoc/recommended-typescript", "plugin:i/recommended", "plugin:i/typescript", "google", "prettier"],
+  "extends": ["plugin:jsdoc/recommended-typescript", "plugin:i/recommended", "plugin:i/typescript", "google", "plugin:prettier/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
@@ -10,9 +10,8 @@
     "project": "./tsconfig.json"
   },
   "ignorePatterns": ["dist"],
-  "plugins": ["@typescript-eslint", "prettier", "jsdoc", "i"],
+  "plugins": ["@typescript-eslint", "jsdoc", "i", "prettier"],
   "rules": {
-    "prettier/prettier": ["warn"],
     "require-await": ["warn"],
     "no-unused-vars": "off",
     "@typescript-eslint/consistent-type-imports": ["warn"],
@@ -37,6 +36,11 @@
     }],
     "new-cap": ["warn", { "capIsNewExceptions": ["Router"] }],
     "quotes": ["warn", "double", { "avoidEscape": true }],
-    "max-len": ["warn", { "code": 120 }]
+    "max-len": ["warn", { "code": 120 }],
+    "prettier/prettier": ["warn", {
+      "printWidth": 120,
+      "tabWidth": 2,
+      "useTabs": false
+    }]
   }
 }

--- a/packages/commons/.eslintrc.json
+++ b/packages/commons/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "shared-node-browser": true
   },
-  "extends": ["plugin:jsdoc/recommended-typescript", "plugin:i/recommended", "plugin:i/typescript", "google", "prettier"],
+  "extends": ["plugin:jsdoc/recommended-typescript", "plugin:i/recommended", "plugin:i/typescript", "google", "plugin:prettier/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
@@ -10,9 +10,8 @@
     "project": "./tsconfig.json"
   },
   "ignorePatterns": ["dist"],
-  "plugins": ["@typescript-eslint", "prettier", "jsdoc", "i"],
+  "plugins": ["@typescript-eslint", "jsdoc", "i", "prettier"],
   "rules": {
-    "prettier/prettier": ["warn"],
     "require-await": ["warn"],
     "no-unused-vars": "off",
     "@typescript-eslint/consistent-type-imports": ["warn"],
@@ -36,6 +35,11 @@
       },
       "warnOnUnassignedImports": true
     }],
-    "max-len": ["warn", { "code": 120 }]
+    "max-len": ["warn", { "code": 120 }],
+    "prettier/prettier": ["warn", {
+      "printWidth": 120,
+      "tabWidth": 2,
+      "useTabs": false
+    }]
   }
 }

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "browser": true
   },
-  "extends": ["plugin:react/recommended", "plugin:jsdoc/recommended-typescript", "plugin:i/recommended", "plugin:i/typescript", "google", "prettier"],
+  "extends": ["plugin:react/recommended", "plugin:jsdoc/recommended-typescript", "plugin:i/recommended", "plugin:i/typescript", "google", "plugin:prettier/recommended"],
   "settings": {
     "react": {
       "version": "detect"
@@ -17,9 +17,8 @@
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
-  "plugins": ["react", "@typescript-eslint", "prettier", "jsdoc", "import"],
+  "plugins": ["react", "@typescript-eslint", "jsdoc", "i", "prettier"],
   "rules": {
-    "prettier/prettier": ["warn"],
     "no-unused-vars": "off",
     "@typescript-eslint/consistent-type-imports": ["warn"],
     "@typescript-eslint/no-unused-vars": ["warn"],
@@ -44,6 +43,11 @@
       },
       "warnOnUnassignedImports": true
     }],
-    "max-len": ["warn", { "code": 120 }]
+    "max-len": ["warn", { "code": 120 }],
+    "prettier/prettier": ["warn", {
+      "printWidth": 120,
+      "tabWidth": 2,
+      "useTabs": false
+    }]
   }
 }

--- a/packages/frontend/public/robots.txt
+++ b/packages/frontend/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/packages/frontend/public/robots.txt
+++ b/packages/frontend/public/robots.txt
@@ -1,3 +1,2 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -2,9 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
-    <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)">
-    <meta name="theme-color" content="#202020" media="(prefers-color-scheme: dark)">
+    <meta id="meta-theme-color-light" name="theme-color" content="#F5F5F5" media="(prefers-color-scheme: light)">
+    <meta id="meta-theme-color-dark" name="theme-color" content="#171717" media="(prefers-color-scheme: dark)">
     <meta name="description" content="A web service fetching and providing financial and ESG ratings for stocks.">
     <link rel="preconnect" href="https://rsms.me/">
     <link rel="preload" href="https://rsms.me/inter/inter.css" as="style" crossorigin referrerpolicy="no-referrer">

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta id="meta-theme-color-light" name="theme-color" content="#F5F5F5" media="(prefers-color-scheme: light)">
     <meta id="meta-theme-color-dark" name="theme-color" content="#171717" media="(prefers-color-scheme: dark)">
     <meta name="description" content="A web service fetching and providing financial and ESG ratings for stocks.">

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -3,6 +3,13 @@ import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 
+if (/iPad|iPhone|iPod/.test(navigator.platform)) {
+  const viewportMeta = document.createElement("meta");
+  viewportMeta.name = "viewport";
+  viewportMeta.content = "width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no";
+  document.head.appendChild(viewportMeta);
+}
+
 createRoot(document.getElementById("root")).render(
   <BrowserRouter>
     <App />

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -3,12 +3,10 @@ import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 
-if (/iPad|iPhone|iPod/.test(navigator.platform)) {
-  const viewportMeta = document.createElement("meta");
-  viewportMeta.name = "viewport";
-  viewportMeta.content = "width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no";
-  document.head.appendChild(viewportMeta);
-}
+if (/iPad|iPhone|iPod/.test(navigator.platform))
+  document
+    .querySelector('meta[name="viewport"]')
+    ?.setAttribute("content", "width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no");
 
 createRoot(document.getElementById("root")).render(
   <BrowserRouter>

--- a/packages/frontend/src/layouts/SidebarLayout/Header/Header.tsx
+++ b/packages/frontend/src/layouts/SidebarLayout/Header/Header.tsx
@@ -1,6 +1,7 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import MenuIcon from "@mui/icons-material/Menu";
 import { Box, alpha, lighten, IconButton, Tooltip, useTheme, Divider } from "@mui/material";
+import { useEffect } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 
 import { HeaderButtons } from "./Buttons/Buttons";
@@ -14,6 +15,15 @@ import { HeaderUserbox } from "./Userbox/Userbox";
 export const Header = (props: HeaderProps): JSX.Element => {
   const theme = useTheme();
   const { pathname } = useLocation();
+
+  useEffect(() => {
+    document.getElementById(`meta-theme-color-${theme.palette.mode}`)?.setAttribute("content", theme.header.background);
+    return () => {
+      document
+        .getElementById(`meta-theme-color-${theme.palette.mode}`)
+        ?.setAttribute("content", theme.palette.background.default);
+    };
+  }, [theme.palette.mode]);
 
   return (
     <Box

--- a/packages/frontend/src/layouts/SidebarLayout/Sidebar/Sidebar.tsx
+++ b/packages/frontend/src/layouts/SidebarLayout/Sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ const SidebarWrapper: FC<React.PropsWithChildren<BoxProps>> = (
   props: React.PropsWithChildren<BoxProps>,
 ): JSX.Element => {
   const theme = useTheme();
+
   return (
     <Box
       width={theme.sidebar.width}


### PR DESCRIPTION
* Add `viewport` meta tag `maximum-scale` attribute only for iOS
* Change `theme-color` meta tag based on context
* Remove `robots.txt`
* Integrate Prettier configuration into ESLint configuration