### PR TITLE
Add trailing slash to Swagger UI URL

### DIFF
--- a/packages/backend/src/server.live.test.ts
+++ b/packages/backend/src/server.live.test.ts
@@ -18,7 +18,11 @@ tests.push({
 tests.push({
   testName: "provides Swagger UI",
   testFunction: async () => {
-    const res = await app.request("/api-docs");
+    let res = await app.request("/api-docs");
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toMatch("/api-docs/");
+
+    res = await app.request("/api-docs/");
     const body = await res.text();
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toMatch("text/html");

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -136,7 +136,7 @@ app.use(async (c, next) => {
 });
 
 // Add security-related headers
-app.use("/api-docs", async (c, next) => {
+app.use("/api-docs/", async (c, next) => {
   await next();
   // Override CSP, COEP, CORP for the Swagger UI
   const csp = c.res.headers.get("Content-Security-Policy");
@@ -195,7 +195,8 @@ app.use(...staticFileHandler);
 app.use(sessionValidator(sessionService));
 
 // Host the OpenAPI UI
-app.get("/api-docs", swaggerUI({ url: "/api-spec/v3.1" }));
+app.get("/api-docs", (c) => c.redirect("/api-docs/", 301));
+app.get("/api-docs/", swaggerUI({ url: "/api-spec/v3.1" }));
 
 // Host the OpenAPI JSON configuration
 app.doc31("/api-spec/v3.1", {


### PR DESCRIPTION
* Redirect to correct URL when trailing slash is missing